### PR TITLE
added the vector Stoner Hamiltonian

### DIFF
--- a/JobDef.json
+++ b/JobDef.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "pcase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/features/support/scase_dimer.json
+++ b/features/support/scase_dimer.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "scase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/features/support/scase_dimer_input_density_matrix.json
+++ b/features/support/scase_dimer_input_density_matrix.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "scase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/features/support/single_hydrogen_job_def.json
+++ b/features/support/single_hydrogen_job_def.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBhydrocarbons",
 
-    // Hamiltonian, "collinear", "noncollinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "collinear",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/pylato/hamiltonian.py
+++ b/pylato/hamiltonian.py
@@ -405,6 +405,9 @@ class Hamiltonian:
                                     Job.NOrb, rho)
         if hami == "collinear":
             return self.add_H_collinear(Job, ii, jj)
+        if hami == "vector_stoner":
+            return self.add_H_pcase(ii, jj, U, J_S, 0, Job.NAtom, Job.NOrb,
+                                    rho)
         else:
             raise UnimplementedModelError(
                 "Hamiltonian: '{}' is unrecognised".format(hami)

--- a/pylato/init_job.py
+++ b/pylato/init_job.py
@@ -36,11 +36,12 @@ class InitJob:
 
         # set isNoncollinearHami flag
         self.isNoncollinearHami = False
-        if self.Def['Hamiltonian'] in ('scase', 'pcase', 'dcase'):
+        if self.Def['Hamiltonian'] in ('scase', 'pcase', 'dcase',
+                                       'vector_stoner'):
             self.isNoncollinearHami = True
 
         # Catch invalid model path
-        if os.path.exists(modelpath) == False:
+        if os.path.exists(modelpath) is False:
             print("ERROR: Unable to open tight binding model at %s. ")
             print(modelpath)
             sys.exit()
@@ -48,7 +49,7 @@ class InitJob:
         # Has a directory for results been specified?
         if "results_dir" in self.Def.keys():
             # check to make sure that it has the final "/"
-            if self.Def['results_dir'][-1]=="/":
+            if self.Def['results_dir'][-1] == "/":
                 self.results_dir = self.Def['results_dir']
             else:
                 self.results_dir = self.Def['results_dir']+"/"

--- a/test_data/JobDef_collinear.json
+++ b/test_data/JobDef_collinear.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBhydrocarbons",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "collinear",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/test_data/JobDef_dcase.json
+++ b/test_data/JobDef_dcase.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "dcase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/test_data/JobDef_input_density_matrix.json
+++ b/test_data/JobDef_input_density_matrix.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "scase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/test_data/JobDef_scase.json
+++ b/test_data/JobDef_scase.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBcanonical",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "scase",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/test_data/JobDef_single_atom.json
+++ b/test_data/JobDef_single_atom.json
@@ -2,7 +2,7 @@
     // tight binding model
     "model": "TBhydrocarbons",
 
-    // Hamiltonian, "collinear", "scase", "pcase" or "dcase"
+    // Hamiltonian, "collinear", "scase", "pcase", "dcase" or "vector_stoner"
     "Hamiltonian": "collinear",
 
     // Periodic boundary conditions: 1 (on) or 0 (off)

--- a/tests/pylato/test_hamiltonian.py
+++ b/tests/pylato/test_hamiltonian.py
@@ -126,6 +126,8 @@ class TestHamiltonian:
             ("scase", 1, 0, 0, [1], 1),
             ("pcase", 1, 1, 0, [3], 5),
             ("dcase", 1, 1, 1, [5], 18),
+            ("vector_stoner", 1, 1, 0, [3], 4),
+            ("vector_stoner", 1, 1, 1, [5], 6),
         ]
 
     )


### PR DESCRIPTION
To use the vector Stoner hamiltonian, you will have to explicitly state which canonical model you want to use, i.e. "TBcanonical_p" or "TBcanonical_d" in the JobDef.json file.